### PR TITLE
Implement basic WPF Daily clone

### DIFF
--- a/DailyForWindows.Tests/DailyForWindows.Tests.csproj
+++ b/DailyForWindows.Tests/DailyForWindows.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DailyForWindows\DailyForWindows.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+  </ItemGroup>
+</Project>

--- a/DailyForWindows.Tests/LogServiceTests.cs
+++ b/DailyForWindows.Tests/LogServiceTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.IO;
+using DailyForWindows.Models;
+using DailyForWindows.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DailyForWindows.Tests
+{
+    [TestClass]
+    public class LogServiceTests
+    {
+        [TestMethod]
+        public void WriteAndReadEntries()
+        {
+            var tmp = Path.GetTempFileName();
+            try
+            {
+                var log = new LogService(tmp);
+                var e = new LogEntry { Timestamp = DateTime.Now, Text = "test" };
+                log.Append(e);
+                var list = log.ReadAll();
+                Assert.AreEqual(1, list.Count);
+                Assert.AreEqual("test", list[0].Text);
+            }
+            finally
+            {
+                File.Delete(tmp);
+            }
+        }
+    }
+}

--- a/DailyForWindows.Tests/PromptSchedulerTests.cs
+++ b/DailyForWindows.Tests/PromptSchedulerTests.cs
@@ -1,0 +1,23 @@
+using System;
+using DailyForWindows.Models;
+using DailyForWindows.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace DailyForWindows.Tests
+{
+    [TestClass]
+    public class PromptSchedulerTests
+    {
+        [TestMethod]
+        public void SnoozeChangesNextTime()
+        {
+            var settings = new AppSettings { IntervalMinutes = 30 };
+            var scheduler = new PromptScheduler(settings, () => { });
+            scheduler.Start();
+            var before = scheduler.NextTime;
+            scheduler.Snooze(10);
+            Assert.IsTrue(scheduler.NextTime > before && scheduler.NextTime - DateTime.Now <= TimeSpan.FromMinutes(10));
+            scheduler.Dispose();
+        }
+    }
+}

--- a/DailyForWindows.sln
+++ b/DailyForWindows.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DailyForWindows", "DailyForWindows\DailyForWindows.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DailyForWindows.Tests", "DailyForWindows.Tests\DailyForWindows.Tests.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/DailyForWindows/App.xaml
+++ b/DailyForWindows/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="DailyForWindows.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/DailyForWindows/App.xaml.cs
+++ b/DailyForWindows/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace DailyForWindows
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/DailyForWindows/DailyForWindows.csproj
+++ b/DailyForWindows/DailyForWindows.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+</Project>

--- a/DailyForWindows/MainWindow.xaml
+++ b/DailyForWindows/MainWindow.xaml
@@ -1,0 +1,6 @@
+<Window x:Class="DailyForWindows.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Daily" Height="0" Width="0" WindowStyle="None" ShowInTaskbar="False" Visibility="Hidden">
+    <Grid/>
+</Window>

--- a/DailyForWindows/MainWindow.xaml.cs
+++ b/DailyForWindows/MainWindow.xaml.cs
@@ -1,0 +1,52 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows;
+using System.Windows.Forms;
+using DailyForWindows.ViewModels;
+
+namespace DailyForWindows
+{
+    public partial class MainWindow : Window
+    {
+        private readonly NotifyIcon _notifyIcon;
+        private readonly MainViewModel _vm;
+
+        public MainWindow()
+        {
+            InitializeComponent();
+            _vm = new MainViewModel();
+            DataContext = _vm;
+
+            _notifyIcon = new NotifyIcon
+            {
+                Icon = SystemIcons.Application,
+                Visible = true,
+                Text = "DailyForWindows"
+            };
+
+            var menu = new ContextMenuStrip();
+            menu.Items.Add("History", null, (_, __) =>
+            {
+                var win = new Views.HistoryWindow { DataContext = _vm, Owner = this };
+                win.ShowDialog();
+            });
+            menu.Items.Add("Settings", null, (_, __) =>
+            {
+                var win = new Views.SettingsWindow { DataContext = _vm, Owner = this };
+                win.ShowDialog();
+            });
+            menu.Items.Add("Exit", null, (_, __) => Close());
+            _notifyIcon.ContextMenuStrip = menu;
+
+            Closing += OnClosing;
+
+            Services.AutostartService.EnableAutostart();
+        }
+
+        private void OnClosing(object? sender, CancelEventArgs e)
+        {
+            _notifyIcon.Visible = false;
+        }
+    }
+}

--- a/DailyForWindows/Models/AppSettings.cs
+++ b/DailyForWindows/Models/AppSettings.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace DailyForWindows.Models
+{
+    public class AppSettings
+    {
+        public int IntervalMinutes { get; set; } = 30;
+        public int SnoozeMinutes { get; set; } = 5;
+        public string LogFilePath { get; set; } = string.Empty;
+        public TimeSpan StartHour { get; set; } = TimeSpan.FromHours(9);
+        public TimeSpan EndHour { get; set; } = TimeSpan.FromHours(17);
+    }
+}

--- a/DailyForWindows/Models/LogEntry.cs
+++ b/DailyForWindows/Models/LogEntry.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace DailyForWindows.Models
+{
+    public class LogEntry
+    {
+        public DateTime Timestamp { get; set; }
+        public string Text { get; set; } = string.Empty;
+    }
+}

--- a/DailyForWindows/Services/AutostartService.cs
+++ b/DailyForWindows/Services/AutostartService.cs
@@ -1,0 +1,17 @@
+using Microsoft.Win32;
+using System;
+using System.Reflection;
+
+namespace DailyForWindows.Services
+{
+    public static class AutostartService
+    {
+        private const string RUN_KEY = "Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+
+        public static void EnableAutostart()
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RUN_KEY, true);
+            key?.SetValue("DailyForWindows", Assembly.GetExecutingAssembly().Location);
+        }
+    }
+}

--- a/DailyForWindows/Services/LogService.cs
+++ b/DailyForWindows/Services/LogService.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using DailyForWindows.Models;
+
+namespace DailyForWindows.Services
+{
+    public class LogService
+    {
+        private readonly ReaderWriterLockSlim _lock = new();
+        private readonly string _filePath;
+
+        public LogService(string filePath)
+        {
+            _filePath = filePath;
+        }
+
+        public void Append(LogEntry entry)
+        {
+            var line = string.Format(CultureInfo.InvariantCulture, "{0},{1}", entry.Timestamp.ToString("o"), entry.Text.Replace("\n", " "));
+            _lock.EnterWriteLock();
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+                File.AppendAllText(_filePath, line + Environment.NewLine, Encoding.UTF8);
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        public IList<LogEntry> ReadAll()
+        {
+            _lock.EnterReadLock();
+            try
+            {
+                if (!File.Exists(_filePath)) return new List<LogEntry>();
+                return File.ReadAllLines(_filePath, Encoding.UTF8)
+                    .Where(l => !string.IsNullOrWhiteSpace(l))
+                    .Select(ParseLine)
+                    .ToList();
+            }
+            finally
+            {
+                _lock.ExitReadLock();
+            }
+        }
+
+        public void WriteAll(IEnumerable<LogEntry> entries)
+        {
+            _lock.EnterWriteLock();
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+                File.WriteAllLines(_filePath,
+                    entries.Select(e => string.Format(CultureInfo.InvariantCulture, "{0},{1}", e.Timestamp.ToString("o"), e.Text.Replace("\n", " "))),
+                    Encoding.UTF8);
+            }
+            finally
+            {
+                _lock.ExitWriteLock();
+            }
+        }
+
+        private static LogEntry ParseLine(string line)
+        {
+            var comma = line.IndexOf(',');
+            if (comma < 0) return new LogEntry { Timestamp = DateTime.Now, Text = line };
+            var ts = DateTime.Parse(line.Substring(0, comma), null, DateTimeStyles.RoundtripKind);
+            var text = line[(comma + 1)..];
+            return new LogEntry { Timestamp = ts, Text = text };
+        }
+    }
+}

--- a/DailyForWindows/Services/PromptScheduler.cs
+++ b/DailyForWindows/Services/PromptScheduler.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Threading;
+using DailyForWindows.Models;
+
+namespace DailyForWindows.Services
+{
+    public class PromptScheduler : IDisposable
+    {
+        private Timer? _timer;
+        private readonly Action _callback;
+        private AppSettings _settings;
+        private DateTime _nextTime;
+
+        public PromptScheduler(AppSettings settings, Action callback)
+        {
+            _settings = settings;
+            _callback = callback;
+        }
+
+        public void UpdateSettings(AppSettings settings)
+        {
+            _settings = settings;
+            ScheduleNext();
+        }
+
+        public void Start()
+        {
+            ScheduleNext();
+        }
+
+        private void ScheduleNext()
+        {
+            _timer?.Dispose();
+            var now = DateTime.Now;
+            var next = now + TimeSpan.FromMinutes(_settings.IntervalMinutes);
+            if (next.TimeOfDay < _settings.StartHour)
+                next = now.Date + _settings.StartHour;
+            if (next.TimeOfDay > _settings.EndHour)
+                next = now.Date.AddDays(1) + _settings.StartHour;
+            _nextTime = next;
+            var due = next - now;
+            _timer = new Timer(_ => _callback(), null, due, Timeout.InfiniteTimeSpan);
+        }
+
+        public void Snooze(int minutes)
+        {
+            _timer?.Dispose();
+            var now = DateTime.Now;
+            _nextTime = now + TimeSpan.FromMinutes(minutes);
+            _timer = new Timer(_ => _callback(), null, TimeSpan.FromMinutes(minutes), Timeout.InfiniteTimeSpan);
+        }
+
+        public DateTime NextTime => _nextTime;
+
+        public void Dispose()
+        {
+            _timer?.Dispose();
+        }
+    }
+}

--- a/DailyForWindows/Services/SettingsService.cs
+++ b/DailyForWindows/Services/SettingsService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using DailyForWindows.Models;
+
+namespace DailyForWindows.Services
+{
+    public class SettingsService
+    {
+        private readonly string _path;
+
+        public SettingsService(string path)
+        {
+            _path = path;
+        }
+
+        public AppSettings Load()
+        {
+            try
+            {
+                if (File.Exists(_path))
+                {
+                    var json = File.ReadAllText(_path);
+                    var settings = JsonSerializer.Deserialize<AppSettings>(json);
+                    if (settings != null) return settings;
+                }
+            }
+            catch { }
+            return new AppSettings { LogFilePath = GetDefaultLogPath() };
+        }
+
+        public void Save(AppSettings settings)
+        {
+            try
+            {
+                Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+                var json = JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true });
+                File.WriteAllText(_path, json);
+            }
+            catch { }
+        }
+
+        public static string GetDefaultSettingsPath()
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return Path.Combine(appData, "DailyForWindows", "settings.json");
+        }
+
+        public static string GetDefaultLogPath()
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            return Path.Combine(appData, "DailyForWindows", "log.csv");
+        }
+    }
+}

--- a/DailyForWindows/ViewModels/BaseViewModel.cs
+++ b/DailyForWindows/ViewModels/BaseViewModel.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace DailyForWindows.ViewModels
+{
+    public class BaseViewModel : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? name = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+        }
+    }
+}

--- a/DailyForWindows/ViewModels/MainViewModel.cs
+++ b/DailyForWindows/ViewModels/MainViewModel.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using DailyForWindows.Models;
+using DailyForWindows.Services;
+
+namespace DailyForWindows.ViewModels
+{
+    public class MainViewModel : BaseViewModel
+    {
+        private readonly LogService _logService;
+        private readonly PromptScheduler _scheduler;
+        private readonly SettingsService _settingsService;
+        private AppSettings _settings;
+
+        public ObservableCollection<LogEntry> Entries { get; } = new();
+
+        public MainViewModel()
+        {
+            _settingsService = new SettingsService(SettingsService.GetDefaultSettingsPath());
+            _settings = _settingsService.Load();
+            if (string.IsNullOrEmpty(_settings.LogFilePath))
+                _settings.LogFilePath = SettingsService.GetDefaultLogPath();
+            _logService = new LogService(_settings.LogFilePath);
+            foreach (var e in _logService.ReadAll().OrderByDescending(e => e.Timestamp))
+                Entries.Add(e);
+            _scheduler = new PromptScheduler(_settings, OnTimer);
+            _scheduler.Start();
+        }
+
+        private void OnTimer()
+        {
+            Application.Current.Dispatcher.Invoke(() => Prompt());
+        }
+
+        public void Prompt()
+        {
+            var window = new Views.PromptWindow { DataContext = this };
+            window.Owner = Application.Current.MainWindow;
+            window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            window.ShowDialog();
+        }
+
+        public void AddEntry(string text)
+        {
+            var entry = new LogEntry { Timestamp = DateTime.Now, Text = text };
+            Entries.Insert(0, entry);
+            try
+            {
+                _logService.Append(entry);
+            }
+            catch
+            {
+                MessageBox.Show("Failed to write log file.");
+            }
+            _scheduler.Start();
+            OnPropertyChanged(nameof(NextPromptTime));
+        }
+
+        public void Snooze()
+        {
+            _scheduler.Snooze(_settings.SnoozeMinutes);
+            OnPropertyChanged(nameof(NextPromptTime));
+        }
+
+        public DateTime NextPromptTime => _scheduler.NextTime;
+
+        public void SaveSettings(AppSettings settings)
+        {
+            _settings = settings;
+            _settingsService.Save(settings);
+            _logService.WriteAll(Entries);
+            _scheduler.UpdateSettings(settings);
+            OnPropertyChanged(nameof(NextPromptTime));
+        }
+
+        public AppSettings Settings => _settings;
+    }
+}

--- a/DailyForWindows/Views/HistoryWindow.xaml
+++ b/DailyForWindows/Views/HistoryWindow.xaml
@@ -1,0 +1,14 @@
+<Window x:Class="DailyForWindows.Views.HistoryWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="History" Height="400" Width="500" WindowStartupLocation="CenterOwner">
+    <Grid>
+        <DataGrid ItemsSource="{Binding Entries}" AutoGenerateColumns="False" CanUserAddRows="False" CanUserDeleteRows="True" Margin="10" SelectionUnit="FullRow" Name="Grid">
+            <DataGrid.Columns>
+                <DataGridTextColumn Header="Timestamp" Binding="{Binding Timestamp}" Width="150" IsReadOnly="True"/>
+                <DataGridTextColumn Header="Text" Binding="{Binding Text}" Width="*"/>
+            </DataGrid.Columns>
+        </DataGrid>
+        <Button Content="Save" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10" Width="80" Name="SaveButton"/>
+    </Grid>
+</Window>

--- a/DailyForWindows/Views/HistoryWindow.xaml.cs
+++ b/DailyForWindows/Views/HistoryWindow.xaml.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using System.Windows;
+
+namespace DailyForWindows.Views
+{
+    public partial class HistoryWindow : Window
+    {
+        public HistoryWindow()
+        {
+            InitializeComponent();
+            SaveButton.Click += (s, e) =>
+            {
+                if (DataContext is ViewModels.MainViewModel vm)
+                {
+                    vm.SaveSettings(vm.Settings);
+                    Close();
+                }
+            };
+        }
+    }
+}

--- a/DailyForWindows/Views/PromptWindow.xaml
+++ b/DailyForWindows/Views/PromptWindow.xaml
@@ -1,0 +1,12 @@
+<Window x:Class="DailyForWindows.Views.PromptWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="What Are You Doing?" Height="150" Width="400" WindowStyle="ToolWindow" ResizeMode="NoResize" Topmost="True">
+    <StackPanel Margin="10">
+        <TextBox Name="InputBox" Margin="0,0,0,10" />
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button Name="OkButton" Content="OK" Width="80" Margin="0,0,5,0" />
+            <Button Name="SnoozeButton" Content="Snooze" Width="80" />
+        </StackPanel>
+    </StackPanel>
+</Window>

--- a/DailyForWindows/Views/PromptWindow.xaml.cs
+++ b/DailyForWindows/Views/PromptWindow.xaml.cs
@@ -1,0 +1,25 @@
+using System.Windows;
+
+namespace DailyForWindows.Views
+{
+    public partial class PromptWindow : Window
+    {
+        public PromptWindow()
+        {
+            InitializeComponent();
+            Loaded += (s, e) => InputBox.Focus();
+            OkButton.Click += (s, e) =>
+            {
+                if (DataContext is ViewModels.MainViewModel vm)
+                    vm.AddEntry(InputBox.Text);
+                Close();
+            };
+            SnoozeButton.Click += (s, e) =>
+            {
+                if (DataContext is ViewModels.MainViewModel vm)
+                    vm.Snooze();
+                Close();
+            };
+        }
+    }
+}

--- a/DailyForWindows/Views/SettingsWindow.xaml
+++ b/DailyForWindows/Views/SettingsWindow.xaml
@@ -1,0 +1,28 @@
+<Window x:Class="DailyForWindows.Views.SettingsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Settings" Height="300" Width="300" WindowStartupLocation="CenterOwner">
+    <StackPanel Margin="10">
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="Interval (minutes):" Width="120" VerticalAlignment="Center"/>
+            <TextBox Text="{Binding Settings.IntervalMinutes}" Width="40"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="Snooze (minutes):" Width="120" VerticalAlignment="Center"/>
+            <TextBox Text="{Binding Settings.SnoozeMinutes}" Width="40"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="Start Hour:" Width="120" VerticalAlignment="Center"/>
+            <TextBox Text="{Binding Settings.StartHour}" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="End Hour:" Width="120" VerticalAlignment="Center"/>
+            <TextBox Text="{Binding Settings.EndHour}" Width="80"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,5">
+            <TextBlock Text="Log File:" Width="120" VerticalAlignment="Center"/>
+            <TextBox Text="{Binding Settings.LogFilePath}" Width="150"/>
+        </StackPanel>
+        <Button Content="Save" HorizontalAlignment="Right" Width="80" Name="SaveButton"/>
+    </StackPanel>
+</Window>

--- a/DailyForWindows/Views/SettingsWindow.xaml.cs
+++ b/DailyForWindows/Views/SettingsWindow.xaml.cs
@@ -1,0 +1,20 @@
+using System.Windows;
+
+namespace DailyForWindows.Views
+{
+    public partial class SettingsWindow : Window
+    {
+        public SettingsWindow()
+        {
+            InitializeComponent();
+            SaveButton.Click += (s, e) =>
+            {
+                if (DataContext is ViewModels.MainViewModel vm)
+                {
+                    vm.SaveSettings(vm.Settings);
+                    Close();
+                }
+            };
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# project
+# DailyForWindows
+
+This is a minimal WPF implementation that mimics the core features of the macOS **Daily** application.
+
+## Features
+
+- Runs in the system tray and automatically starts on login.
+- Periodically prompts the user with a dialog asking "What are you doing?".
+- Entries are appended to a CSV log file under `%APPDATA%\DailyForWindows\log.csv`.
+- History and settings windows allow managing past entries and configuration.
+- Settings are stored in `%APPDATA%\DailyForWindows\settings.json`.
+
+## Building
+
+```
+dotnet build DailyForWindows.sln
+```
+
+## Testing
+
+```
+dotnet test DailyForWindows.sln
+```
+
+The tests cover the timer and log service components.


### PR DESCRIPTION
## Summary
- add WPF solution for **DailyForWindows** with MVVM structure
- implement tray icon with autostart
- implement prompt, history and settings windows
- add logging and settings services
- include basic unit tests and README instructions

## Testing
- `dotnet test DailyForWindows.sln` *(fails: `dotnet` not found)*